### PR TITLE
Do not lock files when loading assembly

### DIFF
--- a/Partiality/Modloader/ModManager.cs
+++ b/Partiality/Modloader/ModManager.cs
@@ -34,7 +34,7 @@ namespace Partiality.Modloader {
             //Check for dependencies. Load mods that have all dependencies, skip ones that don't.
             foreach( string filePath in modFiles ) {
                 try {
-                    Assembly modAssembly = Assembly.LoadFrom( filePath );
+                    Assembly modAssembly = Assembly.Load(File.ReadAllBytes(filePath));
                     Debug.Log( "Loaded Assembly :" + modAssembly.FullName );
                 } catch( System.Exception e ) {
                     Debug.LogError( e );

--- a/Partiality/Properties/AssemblyInfo.cs
+++ b/Partiality/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.2.0")]
+[assembly: AssemblyFileVersion("0.2.0")]


### PR DESCRIPTION
Hi,

I'm working on a mod that enables hot reloading other mods, but we cannot overwrite `.dll` files  
because they are currently locked by `Partiality` due to the use of `Assembly.LoadFrom(...)`.

The workaround is to load assembly from read file bytes, the counterpart is that the loaded  
assembly does not have a `Location` anymore, if someone cares about.